### PR TITLE
fix: `$ref` support in makeTree

### DIFF
--- a/src/__tests__/helpers/make-tree.js
+++ b/src/__tests__/helpers/make-tree.js
@@ -48,6 +48,28 @@ describe('makeTree', () => {
     `);
   });
 
+  it('works on nested $ref instancePath', async () => {
+    expect(makeTree([{ instancePath: '/root/$ref' }])).toMatchInlineSnapshot(`
+      Object {
+        "children": Object {
+          "/root": Object {
+            "children": Object {
+              "/$ref": Object {
+                "children": Object {},
+                "errors": Array [
+                  Object {
+                    "instancePath": "/root/$ref",
+                  },
+                ],
+              },
+            },
+            "errors": Array [],
+          },
+        },
+      }
+    `);
+  });
+
   it('works on array instancePath', async () => {
     expect(
       makeTree([

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,7 +16,7 @@ import {
 } from './validation-errors/index';
 import ErrorMessageError from './validation-errors/error-message';
 
-const JSON_POINTERS_REGEX = /\/[\w_-]+(\/\d+)?/g;
+const JSON_POINTERS_REGEX = /\/[\w$_-]+(\/\d+)?/g;
 
 // Make a tree of errors from ajv errors array
 export function makeTree(ajvErrors = []) {


### PR DESCRIPTION
Adding `$` to the [`JSON_POINTERS_REGEX `](https://github.com/stoplightio/better-ajv-errors/blob/master/src/helpers.js#L19) to support `$ref` paths.

Follow-ups for fixing the motivating issue:
- release a new minor of this package
- bump the version in `spectral/functions` accordingly

## Motivation and Context
https://github.com/stoplightio/spectral/issues/2245

## Description
<!-- Describe your technical changes in detail. -->


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
Unit test + locally linked [spectral functions dependency](https://github.com/stoplightio/spectral/blob/develop/packages/functions/package.json#L25) to this fix and running the test described in the issue.

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
